### PR TITLE
change broken url

### DIFF
--- a/_includes/omkinstall.md
+++ b/_includes/omkinstall.md
@@ -11,4 +11,4 @@ You can either download ODK Collect on the [Google Play Store](https://play.goog
 
 #### OpenMapKit
 Once the ODK is installed download the OpenMapKit from the [Google Play Store](https://play.google.com/store/apps/developer?id=OpenMapKit) or get the APK  
-[here](http://openmapkit.org/downloads/OpenMapKit/OpenMapKit_v0.12.apk)
+[here](https://github.com/AmericanRedCross/OpenMapKitAndroid/releases)


### PR DESCRIPTION
the link to download the omk apk is both outdated (url has v0.12 in it) and also broken. this changes it to the OpenMapKitAndroid releases github page. 
